### PR TITLE
Fix tree schema recursion and correct users schema syntax

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 // ===================== Auth (placeholder) =====================
 export const users = pgTable("users", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  username: text("username").notNull().
+  username: text("username").notNull(),
   password: text("password").notNull(),
 });
 
@@ -51,7 +51,7 @@ export type EvolutionData = z.infer<typeof evolutionDataSchema>;
 // ===================== Tree (Technology Tree) =====================
 export const treeNodeSchema: z.ZodType<any> = z.lazy(() => z.object({
   name: z.string(),
-  children: z.array(treeNodeSchema).optional(),
+  children: z.array(z.lazy(() => treeNodeSchema)).optional(),
   value: z.number().optional(),
   type: z.string().optional(),
   description: z.string().optional()


### PR DESCRIPTION
## Summary
- ensure the technology tree schema recurses via a lazily evaluated child definition
- fix the users table schema by replacing an extraneous trailing dot after notNull

## Testing
- npm run check *(fails: TS errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb031de6f4832f9e341fc560388e44