### PR TITLE
Add explicit matrix route and fix navigation active state

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ function Router() {
     <Switch>
       <Route path="/tree" component={TreePage} />
       <Route path="/cases" component={CasesPage} />
+      <Route path="/matrix" component={MatrixPage} />
       <Route path="/" component={MatrixPage} />
       <Route component={NotFoundPage} />
     </Switch>

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -5,11 +5,9 @@ import { Button } from "@/components/ui/button";
 export function Navigation() {
   const [location] = useLocation();
 
-  const isActive = (path: string) => {
-    if (path === "/" && (location === "/" || location === "/matrix")) return true;
-    if (path === "/tree" && location === "/tree") return true;
-    if (path === "/cases" && location === "/cases") return true;
-    return false;
+  const isActive = (paths: string | string[]) => {
+    const targetPaths = Array.isArray(paths) ? paths : [paths];
+    return targetPaths.some((path) => path === location);
   };
 
   return (
@@ -17,8 +15,8 @@ export function Navigation() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-center space-x-1 py-4">
           <Link href="/matrix">
-            <Button 
-              variant={isActive("/") ? "default" : "ghost"}
+            <Button
+              variant={isActive(["/", "/matrix"]) ? "default" : "ghost"}
               className="px-6 py-2"
             >
               Матрица


### PR DESCRIPTION
## Summary
- add an explicit /matrix route so reloads do not fall through to the 404 page
- update the navigation active state helper so the Matrix link is highlighted on both / and /matrix

## Testing
- npm run check *(fails: existing missing symbols in technology-importer and type errors in technology-tree)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4364a434832f84a9465ada4aaff1